### PR TITLE
corrected README dir names for grpc example

### DIFF
--- a/grpc/greeter/README.md
+++ b/grpc/greeter/README.md
@@ -9,7 +9,7 @@ An example Go-Micro based GRPC service
 
 Run Service
 ```
-$ go run server/main.go --registry=mdns
+$ go run srv/main.go --registry=mdns
 2016/11/03 18:41:22 Listening on [::]:55194
 2016/11/03 18:41:22 Broker Listening on [::]:55195
 2016/11/03 18:41:22 Registering node: go.micro.srv.greeter-1e200612-a1f5-11e6-8e84-68a86d0d36b6
@@ -17,7 +17,7 @@ $ go run server/main.go --registry=mdns
 
 Test Service
 ```
-$ go run client/main.go --registry=mdns
+$ go run cli/main.go --registry=mdns
 Hello John
 ```
 


### PR DESCRIPTION
The current README instructions are incorrect. 

However is there any reason this example's directory structure is different to the one in `go-grpc` https://github.com/micro/go-grpc/tree/master/examples/greeter ? I.e. to use `cli` and `srv` instead of `client` and `server`?