### PR TITLE
Remove dead link to gRPC sidecar example

### DIFF
--- a/grpc/README.md
+++ b/grpc/README.md
@@ -4,7 +4,6 @@ Contains examples for using [go-grpc](https://github.com/micro/go-grpc)
 
 - [greeter](greeter) - A greeter example
 - [gateway](gateway) - A grpc gateway example
-- [sidecar](sidecar) - Using the micro sidecar for http
 
 ## New service
 


### PR DESCRIPTION
Remove dead link to sidecar gRPC example.