### PR TITLE
fix make proto in booking example Makefile

### DIFF
--- a/booking/Makefile
+++ b/booking/Makefile
@@ -3,7 +3,7 @@
 proto:
 	for d in api srv; do \
 		for f in $$d/**/proto/*.proto; do \
-			protoc --proto_path=${GOPATH}/src --micro_out=. --go_out=. $$f; \
+			protoc --proto_path=${GOPATH}/src:. --micro_out=. --go_out=. $$f; \
 			echo compiled: $$f; \
 		done \
 	done


### PR DESCRIPTION
without ":." protoc doesn't correctly find the .proto files